### PR TITLE
[DRAFT]: refactor: prepare for "endpoint configuration"

### DIFF
--- a/xcashu/client/client.py
+++ b/xcashu/client/client.py
@@ -36,14 +36,15 @@ async def request_wrapped(wallet, *args, **kwargs):
 
     s.headers.update({"X-Cashu": token})
     resp = s.request(*args, **kwargs)
-
-    await wallet.invalidate(proofs, check_spendable=False)
-    if VERBOSE:
-        print(f"Wallet balance: {sum_proofs(wallet.proofs)} sats")
     try:
         resp.raise_for_status()
     except Exception as e:
         print(e)
+    else:
+        await wallet.invalidate(proofs, check_spendable=False)
+        if VERBOSE:
+            print(f"Wallet balance: {sum_proofs(wallet.proofs)} sats")
+
     resp_dict = resp.json()
     print(resp_dict)
     return resp

--- a/xcashu/server/app.py
+++ b/xcashu/server/app.py
@@ -1,59 +1,12 @@
 from fastapi import FastAPI, HTTPException
 from starlette.middleware import Middleware
-from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse
-
 
 from xcashu.server.ledger import startup_cashu_mint
 from xcashu.server.router import router
-from xcashu.server.ledger import csat_router, ledger
+from xcashu.server.ledger import csat_router
 
-from cashu.core.base import TokenV2
-from cashu.core.settings import LIGHTNING
-
-import json
-import base64
-
-
-class EcashHeaderMiddleware(BaseHTTPMiddleware):
-    """
-    Middleware that checks the HTTP headers for ecash
-    """
-
-    async def dispatch(self, request, call_next):
-        # all requests to /cashu/* are not checked for ecash
-        if request.url.path.startswith("/paid/"):
-            # check whether valid ecash was provided in header
-            token = request.headers.get("X-Cashu")
-            if not token:
-                if LIGHTNING:
-                    payment_request, payment_hash = await ledger.request_mint(1000)
-                else:
-                    payment_request, payment_hash = "payment_request", "payment_hash"
-                return JSONResponse(
-                    {
-                        "detail": "This endpoint requires a X-Cashu ecash header",
-                        "pr": payment_request,
-                        "hash": payment_hash,
-                        "mint": "http://localhost:8000/cashu",
-                    },
-                    status_code=402,
-                )
-            tokenv2 = TokenV2.parse_obj(json.loads(base64.urlsafe_b64decode(token)))
-            proofs = tokenv2.proofs
-            await ledger._set_proofs_pending(proofs)
-            try:
-                await ledger._verify_proofs(proofs)
-                await ledger._invalidate_proofs(proofs)
-            except Exception as e:
-                return JSONResponse({"detail": str(e)}, status_code=402)
-            finally:
-                # delete proofs from pending list
-                await ledger._unset_proofs_pending(proofs)
-
-        response = await call_next(request)
-        return response
+from xcashu.server.middleware import EcashHeaderMiddleware
 
 
 def create_app() -> FastAPI:

--- a/xcashu/server/middleware.py
+++ b/xcashu/server/middleware.py
@@ -1,0 +1,130 @@
+import json
+import base64
+
+from fastapi.responses import JSONResponse
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from cashu.core.base import TokenV2
+from cashu.core.settings import LIGHTNING
+from cashu.core.helpers import sum_proofs
+
+from xcashu.server.ledger import ledger
+
+
+class EcashHeaderMiddleware(BaseHTTPMiddleware):
+    """
+    Middleware that checks the HTTP headers for ecash
+    """
+
+    async def dispatch(self, request, call_next):
+        if is_payment_required(request.url.path):
+            # check whether valid ecash was provided in header
+            token = get_payment_token(request)
+            required_amount = get_required_amount(request.url.path)
+            if not token:
+                return await payment_information(get_invoice_amount(request))
+
+            error = await handle_payment(token, required_amount)
+            if error:
+                return error
+
+        return await call_next(request)
+
+
+def is_payment_required(path: str) -> bool:
+    """
+    Check whether the path requires ecash
+    """
+    return get_required_amount(path) > 0
+
+
+def get_required_amount(path: str) -> int:
+    """
+    Get the required amount for the path
+    """
+    # TODO: get paid paths and required amount from config
+    # all requests to /cashu/* are not checked for ecash
+    if path.startswith("/paid/"):
+        return 1
+    return 0
+
+
+def get_payment_token(request) -> str:
+    """
+    Get the payment token from the request
+    """
+    # TODO: get header from config?
+    # TODO: a more "generic" way could be to introduce a "Payment" header
+    # and then expect a value "Cashu <payment token>"
+    # Example:
+    # ```
+    # HTTP POST /paid/endpoint
+    # Payment: Cashu <payment token>
+    # ```
+    # Similar to how the `Authorization` header works in HTTP
+    # (Example: `Authorization: Bearer <token>`)
+    return request.headers.get("X-Cashu")
+
+
+def get_invoice_amount(request) -> int:
+    """
+    Get the invoice amount from the request or fallback to 1000
+    """
+    return int(request.headers.get("X-Cashu-Inv-Amnt", "1000"))
+
+
+async def payment_information(required_amount, amount=1000):
+    """
+    Return payment information.
+
+    If LIGHTNING is True, the payment information is a BOLT11 invoice with the
+    specified `amount`.
+    """
+    if LIGHTNING:
+        payment_request, payment_hash = await ledger.request_mint(amount)
+    else:
+        payment_request = f"payment_request: {amount} sats"
+        payment_hash = "payment_hash"
+    return JSONResponse(
+        {
+            "detail": "This endpoint requires a X-Cashu ecash header. "
+                      f"Costs per request: {required_amount} sats",
+            "pr": payment_request,
+            "hash": payment_hash,
+            "mint": "http://localhost:8000/cashu",
+        },
+        status_code=402,
+    )
+
+
+async def handle_payment(token, required_amount):
+    """
+    Handle the payment token.
+
+    Returns None if the payment was successful, otherwise a JSONResponse with
+    the error message and status code.
+    """
+    tokenv2 = TokenV2.parse_obj(json.loads(base64.urlsafe_b64decode(token)))
+    proofs = tokenv2.proofs
+    total_provided = sum_proofs(proofs)
+    if total_provided != required_amount:
+        return JSONResponse(
+            {
+                "detail": "Insufficient amount provided. "
+                          f"Costs per request: {required_amount} sats",
+            },
+            # TODO: use 402 instead of 400? IMHO, 400 could be argued since a
+            # payment is provided, just not enough?
+            status_code=400
+        )
+
+    await ledger._set_proofs_pending(proofs)
+    try:
+        await ledger._verify_proofs(proofs)
+        await ledger._invalidate_proofs(proofs)
+    except Exception as e:
+        return JSONResponse({"detail": str(e)}, status_code=402)
+    finally:
+        # delete proofs from pending list
+        await ledger._unset_proofs_pending(proofs)
+    return None


### PR DESCRIPTION
# Draft - Work in Progress

Early feedback welcome! :)

## Goals

Allow to provide a config that describes what endpoint requires what fees.

Server could provide this config then as an endpoint.
The client could consume that endpoint and prepare the right amounts in advance.

```
GET /.well-known/cashu

{
  „fees“: {
    „/auth/register“: 21,    // anti-spam
    „/auth/login“: 0,
    „/paid/paths/*“: 3,
    „*“: 0                   // fallback for all other routes
  }
}
```